### PR TITLE
feat: create grafana dashboard backup action

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+max_line_length = 100

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## Description
+
+<!--
+Please provide a brief summary of the changes made. Please explain why
+this change was necessary. Was there a problem or an issue this change
+will address? What will be improved with this change?
+-->
+
+## Changes Made
+
+<!--
+Please detail the modifications made. This could include areas such as
+code, documentation, structure, or formatting.
+-->
+
+## Checklist
+
+- [ ] I have followed the project's style and contribution guidelines.
+- [ ] I have performed a self-review of my own changes.
+- [ ] I have made corresponding changes to the documentation.
+- [ ] I have added tests that prove my fix is effective or that my feature works.

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,19 @@
+name: Quality
+
+on:
+  merge_group:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image
+        run: docker build -t grafana-sync-action .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: Release
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    permissions:
+      issues: write
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Needed for semantic-release
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install semantic-release
+        run: |
+          npm install -g @semantic-release/commit-analyzer@13.0.1 \
+          @semantic-release/release-notes-generator@14.0.3 \
+          @semantic-release/github@11.0.1 \
+          semantic-release@24.2.3 \
+          conventional-changelog-conventionalcommits@8.0.0
+
+      - name: Release
+        id: semantic-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          npx semantic-release

--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,99 @@
+{
+  "branches": ["main"],
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits",
+        "parserOpts": {
+          "noteKeywords": [
+            "BREAKING CHANGE",
+            "BREAKING CHANGES",
+            "BREAKING"
+          ]
+        },
+        "presetConfig": {
+          "types": [
+            {
+              "type": "breaking",
+              "section": "Breaking Changes ❗",
+              "hidden": false
+            },
+            {
+              "type": "feat",
+              "section": "New Features 🚀",
+              "hidden": false
+            },
+            {
+              "type": "fix",
+              "section": "Enhancements and Bug Fixes 🐛",
+              "hidden": false
+            },
+            {
+              "type": "docs",
+              "section": "Docs 📖",
+              "hidden": false
+            },
+            {
+              "type": "style",
+              "section": "Styles 🎨",
+              "hidden": false
+            },
+            {
+              "type": "refactor",
+              "section": "Refactor 🔩",
+              "hidden": false
+            },
+            {
+              "type": "perf",
+              "section": "Performances ⚡️",
+              "hidden": false
+            },
+            {
+              "type": "test",
+              "section": "Tests ✅",
+              "hidden": false
+            },
+            {
+              "type": "ci",
+              "section": "CI 🔁",
+              "hidden": false
+            },
+            {
+              "type": "chore",
+              "section": "Chore 🧹",
+              "hidden": false
+            }
+          ]
+        },
+        "writerOpts": {
+          "groupBy": "type",
+          "commitGroupsSort": [
+            "breaking",
+            "feat",
+            "fix"
+          ]
+        }
+      }
+    ],
+    [
+      "@semantic-release/github",
+      {
+        "assets": [
+          {
+            "path": "build/libs/pillarbox-monitoring-transfer.jar"
+          },
+          {
+            "path": "LICENSE",
+            "label": "License"
+          },
+          {
+            "path": "README.md",
+            "label": "Readme"
+          }
+        ]
+      }
+    ]
+  ]
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine:latest
+
+RUN apk add --no-cache ca-certificates git curl jq
+
+COPY export_dashboards.sh /usr/local/bin/export_dashboards.sh
+RUN chmod +x /usr/local/bin/export_dashboards.sh
+
+ENTRYPOINT ["/usr/local/bin/export_dashboards.sh"]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 SRG SSR
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,96 @@
+# Grafana Dashboard Backup Action
+
+A GitHub Action that automates the process of backing up Grafana dashboards.
+
+## Quick Guide
+
+**Prerequisites and Requirements**
+
+- A **Grafana instance** with API access enabled
+- A **GitHub repository** to store dashboard backups
+- **GitHub Actions** enabled in your repository
+- _(Optional)_ A **GitHub Personal Access Token (PAT)** if you want to automate pull request
+  creation.
+
+**Setup**
+
+1. **Create a GitHub repository** to store your Grafana dashboard backups.
+2. **Add the required secrets** to your repository:
+
+- `GRAFANA_URL`: The URL of your Grafana instance.
+- `GRAFANA_API_KEY`: The API key for Grafana authentication.
+- _(Optional)_ `GH_PAT`: A GitHub Personal Access Token with `repo` permissions, needed only if
+  automating PR creation.
+
+3. **Create a workflow file** in `.github/workflows/grafana-backup.yml` with the following content:
+
+  ```yaml
+  name: Grafana Dashboard Backup
+
+  on:
+     schedule:
+       - cron: '0 2 * * *'  # Runs every day at 2 AM UTC
+     workflow_dispatch:  # Allows manual triggering
+
+  jobs:
+     backup:
+       runs-on: ubuntu-latest
+
+       steps:
+         - name: Checkout repository
+           uses: actions/checkout@v4
+
+         - name: Run Grafana Sync
+           uses: srgssr/grafana-sync-action@v1
+           with:
+              grafana-url: ${{ secrets.GRAFANA_URL }}
+              api-key: ${{ secrets.GRAFANA_API_KEY }}
+              output-dir: dashboards
+
+         - name: Commit and Push Changes
+           run: |
+             git config --global user.name "github-actions[bot]"
+             git config --global user.email "github-actions[bot]@users.noreply.github.com"
+             git add dashboards
+             git commit -m "Automated backup of Grafana dashboards" || echo "No changes to commit"
+             git push
+
+         # (Optional) Create a Pull request using peter-evans/create-pull-request
+         - name: Create Pull Request
+           uses: peter-evans/create-pull-request@v7
+           with:
+             token: ${{ secrets.GH_PAT }}
+             commit-message: "chore: automated Grafana dashboard backup"
+             title: "chore: automated backup of Grafana dashboards"
+             body: "This PR contains the latest Grafana dashboard updates."
+             branch: "backup/grafana-dashboards"
+             delete-branch: true
+  ```
+
+**Running the Action**
+
+- The action will **automatically run daily at 2 AM UTC** to check for changes.
+- You can also **manually trigger** the workflow from the GitHub Actions tab.
+- If changes are detected, it will create a **pull request** containing the updated dashboards.
+
+## Contributing
+
+Contributions are welcome! If you'd like to contribute, please follow the project's code style and
+linting rules.
+
+All commits must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
+format to ensure compatibility with our automated release system. A pre-commit hook is available to
+validate commit messages.
+
+You can set up hook to automate these checks before commiting and pushing your changes, to do so
+update the Git hooks path:
+
+```bash
+git config core.hooksPath .githooks/
+```
+
+Refer to our [Contribution Guide](docs/CONTRIBUTING.md) for more detailed information.
+
+## License
+
+This project is licensed under the [MIT License](LICENSE).

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,21 @@
+name: 'Grafana Sync'
+description: 'Sync Grafana dashboards using grafana-sync'
+author: 'SRG SRR <Pillarbox-Team@rts.ch>'
+inputs:
+  grafana-url:
+    description: 'The URL of the Grafana instance'
+    required: true
+  api-key:
+    description: 'Grafana API key'
+    required: true
+  dir:
+    description: 'Directory to store dashboards'
+    required: false
+    default: 'dashboards'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  env:
+    GRAFANA_URL: ${{ inputs.grafana-url }}
+    API_TOKEN: ${{ inputs.api-key }}
+    OUTPUT_DIR: ${{ inputs.dir }}

--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -1,0 +1,66 @@
+# Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers
+pledge to making participation in our project and our community a harassment-free experience for
+everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level
+of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit
+  permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are
+expected to take appropriate and fair corrective action in response to any instances of unacceptable
+behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits,
+code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or
+to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is
+representing the project or its community. Examples of representing a project or community include
+using an official project e-mail address, posting via an official social media account, or acting as
+an appointed representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting
+the project team. The project team will review and investigate all complaints, and will respond in a
+way that it deems appropriate to the circumstances. The project team is obligated to maintain
+confidentiality with regard to the reporter of an incident. Further details of specific enforcement
+policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face
+temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available
+at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+
+[version]: http://contributor-covenant.org/version/1/4/

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,66 @@
+# Contributing
+
+Thank you very much for your interest in contributing to our project! As a public service company,
+we want to shape a product that better matches our user needs and desires. Ideas or direct
+contributions are therefore warmly welcome and will be considered with great care, provided they
+fulfill a few requirements listed in this document. Please read it first before you decide to
+contribute.
+
+## Purpose
+
+Our development team is small, our ability to quickly evaluate a need or a code submission is
+therefore critical. Please follow the present contributing guidelines so that we can efficiently
+consider your proposal. You should also read or our [code of conduct](CODE_OF_CONDUCT.md), providing
+a few guidelines to keep interactions as respectful as possible.
+
+## Contributions we are looking for
+
+Any kind of contribution is welcome, as long as it improves the overall quality of our product, for
+example:
+
+* Requests for new features or ideas.
+* Bug reports or fixes.
+* Documentation improvements.
+* Translation improvements.
+
+Contributions can either take the form of simple issues where you describe the problem you face or
+what you would like to see in our products. If you feel up to the challenge, you can even submit
+code in the form of pull requests which our team will review.
+
+## Contributions we are not looking for
+
+Requests which are too vague or not related to our product will not be taken into account. We also
+have no editorial influence, any issue related to the content available on our platform will simply
+be closed.
+
+## Making a contribution
+
+You can use issues to report bugs, submit ideas or request features. People with a programming
+background can also submit changes directly via pull requests. Creating issues or pull requests
+requires you to own or [open](https://github.com/join) a GitHub account.
+
+If you are not sure about the likelihood of a change you propose to be accepted, please open an
+issue first. We can discuss it there, especially whether it is compatible with our product or not.
+This way you can avoid creating an entire pull request we will never be able to merge.
+
+Templates are available when you want to contribute:
+
+* [Issues](https://github.com/SRGSSR/grafana-sync-action/issues/new/choose): Please follow our issue
+  template. You can omit information which does not make sense but, in general, the more details you
+  can provide, the better. This ensures we can quickly reproduce the problem you are facing,
+  increasing the likelihood we can fix it.
+* [Pull requests](https://github.com/SRGSSR/grafana-sync-action/compare): Please follow our code
+  conventions, test your code well, and write unit tests when this makes sense. We will review your
+  work and, if successful, merge it back into the main development branch.
+
+## Code conventions
+
+We currently have no formal code conventions, but we try to keep our codebase consistent. In
+general, having a look at the code itself should be enough for you to discover how you should write
+your changes.
+
+## Code review
+
+Pull requests, once complete, can be submitted for review by our team. Depending on the complexity
+of the involved changes, a few iterations might be needed. Once a pull request has been approved, it
+will be rebased, merged back into the development trunk and delivered with the next release.

--- a/export_dashboards.sh
+++ b/export_dashboards.sh
@@ -1,0 +1,62 @@
+#!/bin/sh -e
+
+echo "Starting Grafana Export..."
+echo "Grafana URL: ${GRAFANA_URL}"
+echo "Output Directory: ${OUTPUT_DIR}"
+
+# Check if required variables are set
+if [ -z "$GRAFANA_URL" ] || [ -z "$API_TOKEN" ]; then
+    echo "Error: GRAFANA_URL and API_TOKEN must be set!"
+    exit 1
+fi
+
+# Create output directory
+echo "Creating output directory at ${OUTPUT_DIR}..."
+mkdir -p "$OUTPUT_DIR"
+
+# Fetch all folders
+echo "Fetching folders from ${GRAFANA_URL}/api/folders..."
+FOLDERS_JSON=$(curl -s -H "Authorization: Bearer $API_TOKEN" "$GRAFANA_URL/api/folders")
+echo "Fetched folders."
+
+# Function to get a folder's name given its UID
+get_folder_name() {
+    uid="$1"
+    # If uid is empty or null, default to "General"
+    if [ -z "$uid" ] || [ "$uid" = "null" ]; then
+        echo "General"
+        return
+    fi
+    name=$(echo "$FOLDERS_JSON" | jq -r --arg uid "$uid" 'map(select(.uid == $uid)) | .[0].title // "General"')
+    # Sanitize folder name to remove problematic characters
+    echo "$name" | sed 's/[\/\\?%*:|"<>]//g'
+}
+
+# Fetch all dashboards
+echo "Fetching dashboards from ${GRAFANA_URL}/api/search?type=dash-db..."
+DASHBOARDS_JSON=$(curl -s -H "Authorization: Bearer $API_TOKEN" "$GRAFANA_URL/api/search?type=dash-db")
+echo "Fetched dashboards."
+
+# Loop through each dashboard
+echo "$DASHBOARDS_JSON" | jq -c '.[]' | while read -r dashboard; do
+    UID=$(echo "$dashboard" | jq -r '.uid')
+    TITLE=$(echo "$dashboard" | jq -r '.title' | sed 's/[\/\\?%*:|"<>]//g')
+    FOLDER_UID=$(echo "$dashboard" | jq -r '.folderUid')
+
+    FOLDER_NAME=$(get_folder_name "$FOLDER_UID")
+    FOLDER_PATH="$OUTPUT_DIR/$FOLDER_NAME"
+
+    echo "Processing dashboard: '$TITLE' (UID: $UID) in folder: '$FOLDER_NAME'"
+    mkdir -p "$FOLDER_PATH"
+
+    # Fetch dashboard JSON
+    echo "Fetching dashboard details for UID: $UID..."
+    DASHBOARD_JSON=$(curl -s -H "Authorization: Bearer $API_TOKEN" "$GRAFANA_URL/api/dashboards/uid/$UID")
+
+    # Save dashboard JSON to file
+    echo "$DASHBOARD_JSON" | jq '.dashboard' > "$FOLDER_PATH/$TITLE.json"
+    echo "Saved dashboard to: $FOLDER_PATH/$TITLE.json"
+done
+
+echo "Grafana Export completed successfully."
+exit 0


### PR DESCRIPTION
## Description

A GitHub Action that automates the process of backing up Grafana dashboards.

## Changes Made

- Added initial implementation of the Grafana Dashboard Backup Action
- Includes a Docker-based script for exporting dashboards via the Grafana API
- Provides a GitHub Action workflow example for automated backups
- Supports scheduled and manual execution, with optional PR creation for changes
- Uses jq and curl to fetch and save dashboards in structured folders