### PR TITLE
feat: add optional clear flag to wipe target directory before export

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,11 @@ A GitHub Action that automates the process of backing up Grafana dashboards.
             fetch-depth: 0
 
         - name: Run Grafana Sync
-          uses: srgssr/grafana-sync-action@v2.0.0
+          uses: srgssr/grafana-sync-action@v1.2.0
           with:
             grafana-url: ${{ secrets.GRAFANA_URL }}
             api-key: ${{ secrets.GRAFANA_API_KEY }}
+            clear: true
             dir: 'dashboards'
 
         - name: Create Pull Request

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,10 @@ inputs:
     description: 'Directory to store dashboards'
     required: false
     default: 'dashboards'
+  clear:
+    description: 'Whether to clear the target directory before storing new data'
+    required: false
+    default: 'false'
 runs:
   using: 'node20'
   main: 'src/index.mjs'

--- a/src/backup-storage.mjs
+++ b/src/backup-storage.mjs
@@ -41,4 +41,13 @@ export class BackupStorage {
     fs.writeFileSync(outputFilePath, JSON.stringify(dashboard, null, 2));
     console.log(`Saved dashboard to: ${outputFilePath}`);
   }
+
+  /**
+   * Clears all contents (files and subdirectories) of the base directory.
+   * This method recursively deletes all files and folders inside the base directory.
+   */
+  clear() {
+    fs.rmSync(this.baseDir, {recursive: true, force: true});
+    console.log(`Cleared all contents of: ${this.baseDir}`);
+  }
 }

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -3,16 +3,19 @@ import {BackupStorage} from "./backup-storage.mjs";
 import {getInput} from "./utils.mjs";
 
 try {
-  const GRAFANA_URL = getInput('grafana-url');
-  const API_TOKEN = getInput('api-key');
-  const OUTPUT_DIR = getInput('dir', 'dashboards');
+  const grafanaUrl = getInput('grafana-url');
+  const apiToken = getInput('api-key');
+  const outputDir = getInput('dir', 'dashboards');
+  const clear = getInput('clear', 'false') === 'true';
 
   console.log('Starting Grafana Export...');
-  console.log(`Grafana URL: ${GRAFANA_URL}`);
-  console.log(`Output Directory: ${OUTPUT_DIR}`);
+  console.log(`Grafana URL: ${grafanaUrl}`);
+  console.log(`Output Directory: ${outputDir}`);
 
-  const client = new GrafanaClient(GRAFANA_URL, API_TOKEN);
-  const storage = new BackupStorage(OUTPUT_DIR);
+  const client = new GrafanaClient(grafanaUrl, apiToken);
+  const storage = new BackupStorage(outputDir);
+
+  if (clear) storage.clear();
 
   const folders = await client.getFolders();
   const dashboardsData = await client.getDashboards();


### PR DESCRIPTION
## Description

Adds a clear input to optionally delete the target directory before exporting dashboards. 
Defaults to `false` to maintain previous behavior. 
Useful to ensure a clean export without leftover files.

## Changes Made

- Added a `clear` input.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
